### PR TITLE
Use crawl for the first step vs schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ See [CONFIG.md](docs/CONFIG.md) for more details on these files.
 Once everything is configured, you can run a crawl job using the CLI:
 
 ```bash
-$ docker exec -it crawler bin/crawler schedule path/to/my-crawler.yml
+$ docker exec -it crawler bin/crawler crawl path/to/my-crawler.yml
 ```
 
 ### Scheduling Recurring Crawl Jobs


### PR DESCRIPTION
When we just follow the instructions in the README, without configuring any scheduler yet (which is the next step), calling the following command does not work:

```sh
docker exec -it crawler bin/crawler schedule config/my-crawler.yml 
```

It fails with:

```
ArgumentError: No schedule found in config file
              call at /app/lib/crawler/cli/schedule.rb:25
  perform_registry at /usr/local/bundle/gems/dry-cli-0.7.0/lib/dry/cli.rb:116
              call at /usr/local/bundle/gems/dry-cli-0.7.0/lib/dry/cli.rb:65
            <main> at bin/crawler:28
```

Which is expected as we did not configure yet any schedule. So running the following command for the first time seems to be better:

```sh
docker exec -it crawler bin/crawler crawl config/my-crawler.yml 
```

